### PR TITLE
🐛 fix(DataTable): sort icon error when header align was end

### DIFF
--- a/src/Component/BlazorComponent/Components/DataTable/DataTableHeader/Desktop/BDataTableHeaderDesktop.razor
+++ b/src/Component/BlazorComponent/Components/DataTable/DataTableHeader/Desktop/BDataTableHeaderDesktop.razor
@@ -29,7 +29,7 @@
                         @header.Text
                     }
                 </span>
-                @if (!DisableSort && header.Sortable)
+                @if (!DisableSort && header.Sortable && header.Align != DataTableHeaderAlign.End)
                 {
                     var sortIndex = Options.SortBy.IndexOf(header.Value);
                     var beingSorted = sortIndex >= 0;


### PR DESCRIPTION
resolves masastack/MASA.Blazor#1264