### PR TITLE
⚡ refactor(Tabs): no need to render the empty tabs items element

### DIFF
--- a/src/Component/BlazorComponent/Components/Tabs/Body/BTabsBody.razor
+++ b/src/Component/BlazorComponent/Components/Tabs/Body/BTabsBody.razor
@@ -2,7 +2,7 @@
 @typeparam TTabs
 @inherits ComponentPartBase<TTabs>
 
-@if (TabItems != null)
+@if (TabItems.Any())
 {
     <BWindow Value="Value" @attributes="GetAttributes(typeof(BWindow))">
         @foreach (var tabItem in TabItems)


### PR DESCRIPTION
![image](https://github.com/masastack/BlazorComponent/assets/16507773/a2c03d5a-7c8e-4efe-b459-5aa10bf5d302)

a small optimization from masastack/MASA.Blazor#1356