### PR TITLE
🆕 feat(Routable): add `MatchPattern` to routable component

### DIFF
--- a/src/Component/BlazorComponent/Components/Breadcrumbs/BBreadcrumbsItem.razor.cs
+++ b/src/Component/BlazorComponent/Components/Breadcrumbs/BBreadcrumbsItem.razor.cs
@@ -20,9 +20,14 @@ namespace BlazorComponent
         [Parameter]
         public bool Disabled { get; set; }
 
+        /// <inheritdoc />
         [Parameter]
         public bool Exact { get; set; }
 
+        /// <inheritdoc />
+        [Parameter]
+        public string? MatchPattern { get; set; }
+        
         [Parameter]
         public string? Href { get; set; }
 

--- a/src/Component/BlazorComponent/Components/Breadcrumbs/BBreadcrumbsItem.razor.cs
+++ b/src/Component/BlazorComponent/Components/Breadcrumbs/BBreadcrumbsItem.razor.cs
@@ -68,6 +68,7 @@ namespace BlazorComponent
             if (firstRender)
             {
                 UpdateActiveForRoutable();
+                StateHasChanged();
             }
         }
 

--- a/src/Component/BlazorComponent/Components/Chip/BChip.razor.cs
+++ b/src/Component/BlazorComponent/Components/Chip/BChip.razor.cs
@@ -61,6 +61,8 @@
 
         public bool Exact { get; }
 
+        public string? MatchPattern { get; }
+
         public bool IsDark
         {
             get

--- a/src/Component/BlazorComponent/Components/ItemGroup/BRoutableGroupItem.razor.cs
+++ b/src/Component/BlazorComponent/Components/ItemGroup/BRoutableGroupItem.razor.cs
@@ -28,8 +28,13 @@ public partial class BRoutableGroupItem<TGroup> : BGroupItem<TGroup>, IRoutable
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
 
+    /// <inheritdoc />
     [Parameter]
     public bool Exact { get; set; }
+
+    /// <inheritdoc />
+    [Parameter]
+    public string? MatchPattern { get; set; }
 
     protected IRoutable? Router { get; private set; }
 

--- a/src/Component/BlazorComponent/Mixins/Routable/Router.cs
+++ b/src/Component/BlazorComponent/Mixins/Routable/Router.cs
@@ -1,24 +1,38 @@
 ﻿namespace BlazorComponent;
 
-public class Router(IRoutable routable) : IRoutable
+public class Router : IRoutable
 {
-    public IDictionary<string, object?> Attributes { get; set; } = routable.Attributes;
+    public Router(IRoutable routable)
+    {
+        Attributes = routable.Attributes;
+        Disabled = routable.Disabled;
+        Href = routable.Href;
+        Link = routable.Link;
+        OnClick = routable.OnClick;
+        Tag = routable.Tag;
+        Target = routable.Target;
+        Exact = routable.Exact;
+        NavigationManager = routable.NavigationManager;
+        MatchPattern = routable.MatchPattern;
+    }
 
-    public bool Disabled { get; set; } = routable.Disabled;
+    public IDictionary<string, object?> Attributes { get; set; }
 
-    public string? Href { get; set; } = routable.Href;
+    public bool Disabled { get; set; }
 
-    public bool Link { get; set; } = routable.Link;
+    public string? Href { get; set; }
 
-    public EventCallback<MouseEventArgs> OnClick { get; set; } = routable.OnClick;
+    public bool Link { get; set; }
 
-    public string? Tag { get; set; } = routable.Tag;
+    public EventCallback<MouseEventArgs> OnClick { get; set; }
 
-    public string? Target { get; set; } = routable.Target;
+    public string? Tag { get; set; }
 
-    public bool Exact { get; set; } = routable.Exact;
+    public string? Target { get; set; }
 
-    public string? MatchPattern { get; set; } = routable.MatchPattern;
+    public bool Exact { get; set; }
 
-    public NavigationManager NavigationManager { get; set; } = routable.NavigationManager;
+    public string? MatchPattern { get; set; }
+
+    public NavigationManager NavigationManager { get; set; }
 }

--- a/src/Component/BlazorComponent/Mixins/Routable/Router.cs
+++ b/src/Component/BlazorComponent/Mixins/Routable/Router.cs
@@ -1,35 +1,24 @@
 ﻿namespace BlazorComponent;
 
-public class Router : IRoutable
+public class Router(IRoutable routable) : IRoutable
 {
-    public Router(IRoutable routable)
-    {
-        Attributes = routable.Attributes;
-        Disabled = routable.Disabled;
-        Href = routable.Href;
-        Link = routable.Link;
-        OnClick = routable.OnClick;
-        Tag = routable.Tag;
-        Target = routable.Target;
-        Exact = routable.Exact;
-        NavigationManager = routable.NavigationManager;
-    }
+    public IDictionary<string, object?> Attributes { get; set; } = routable.Attributes;
 
-    public IDictionary<string, object?> Attributes { get; set; }
+    public bool Disabled { get; set; } = routable.Disabled;
 
-    public bool Disabled { get; set; }
+    public string? Href { get; set; } = routable.Href;
 
-    public string? Href { get; set; }
+    public bool Link { get; set; } = routable.Link;
 
-    public bool Link { get; set; }
+    public EventCallback<MouseEventArgs> OnClick { get; set; } = routable.OnClick;
 
-    public EventCallback<MouseEventArgs> OnClick { get; set; }
+    public string? Tag { get; set; } = routable.Tag;
 
-    public string? Tag { get; set; }
+    public string? Target { get; set; } = routable.Target;
 
-    public string? Target { get; set; }
+    public bool Exact { get; set; } = routable.Exact;
 
-    public bool Exact { get; set; }
+    public string? MatchPattern { get; set; } = routable.MatchPattern;
 
-    public NavigationManager NavigationManager { get; set; }
+    public NavigationManager NavigationManager { get; set; } = routable.NavigationManager;
 }


### PR DESCRIPTION
```razor
<MList Routable Nav>
    <MListItem Href="/" Exact>Home</MListItem>
    <MListItem Href="/users/list" MatchPattern="/users/(list|details/)[^/]*">Users</MListItem>
</MList>
```

The state of ListItem _Users_ will be active when url is `/users/list` and `/users/details/tom`.