### PR TITLE
🆕 feat(pop-up): support for persistence of pop-up windows when using SSR

### DIFF
--- a/src/Component/BlazorComponent/Components/App/BApp.razor
+++ b/src/Component/BlazorComponent/Components/App/BApp.razor
@@ -15,6 +15,7 @@
                         <DynamicComponent Type="item.ComponentType" Parameters="item.Parameters"></DynamicComponent>
                     </CascadingValue>
                 }
+                <div data-permanent class="m-application__permanent"></div>
             </div>
         </CascadingValue>
     </CascadingValue>

--- a/src/Component/BlazorComponent/Mixins/Menuable/BMenuable.cs
+++ b/src/Component/BlazorComponent/Mixins/Menuable/BMenuable.cs
@@ -66,6 +66,13 @@
         [Parameter]
         public bool OffsetY { get; set; }
 
+        /// <summary>
+        /// The lazy content would be created in a [data-permanent] element.
+        /// It's useful when you use this component in a layout.
+        /// </summary>
+        [Parameter]
+        public bool Permanent { get; set; }
+
         [Parameter]
         public bool ExternalActivator { get; set; }
 


### PR DESCRIPTION
Using `Permenant` parameter in Dialog/Menu/Tooltip components can prevent the failure of the page from popping up after a jump. Usually need to use this parameter on a layout component.